### PR TITLE
Fix caret-down icon on client's quote

### DIFF
--- a/vendor/assets/stylesheets/ombulabs/styleguide/1-utilities/_variables.scss
+++ b/vendor/assets/stylesheets/ombulabs/styleguide/1-utilities/_variables.scss
@@ -27,6 +27,7 @@ $header_height: 90px;
 $font-lato: "Lato", "Helvetica", Arial, sans-serif;
 $font-open-sans: "Open Sans", "Helvetica", Arial, sans-serif;
 $font-maven: "Maven", "Lato", "Helvetica", Arial, sans-serif;
+$font-awesome: 'Font Awesome 5 Free';
 $base-font-size: 17px;
 $base-line-height: 1.4;
 

--- a/vendor/assets/stylesheets/ombulabs/styleguide/4-molecules/_quotes.scss
+++ b/vendor/assets/stylesheets/ombulabs/styleguide/4-molecules/_quotes.scss
@@ -118,7 +118,8 @@
 					}
 					&:before{
 						content: "\f0d7";
-						font-family: 'FontAwesome';
+						font-family: $font-awesome;
+						font-weight: 900;
 						color: $white;
 						font-size: 28px;
 						position: absolute;


### PR DESCRIPTION
This fixes this issue https://www.pivotaltracker.com/story/show/171978309/comments/213130467 setting the correct font-family and font-weight properties