### PR TITLE
Remove a line requiring jquery so projects don't need to use jquery-r…

### DIFF
--- a/lib/ombulabs-styleguide.rb
+++ b/lib/ombulabs-styleguide.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'jquery-rails'
 require 'font-awesome-sass'
 
 module Ombulabs


### PR DESCRIPTION
The styleguide is not using jquery anymore but it was still requiring jquery-rails gem making projects depend on that gem.