### PR TITLE
Fix margin for testimonial carousel. 

### DIFF
--- a/vendor/assets/stylesheets/ombulabs/styleguide/4-molecules/_quotes.scss
+++ b/vendor/assets/stylesheets/ombulabs/styleguide/4-molecules/_quotes.scss
@@ -12,6 +12,9 @@
     font-size: 14px;
     font-weight: 700;
     margin-bottom: 20px;
+    @include respond-below(extra-small) {
+      margin-left: -2em;
+    }
   }
   .carousel{
     position: relative;
@@ -132,7 +135,7 @@
         overflow: initial !important;
         height: 550px !important;
       }
-    }  
+    }
     .bx-pager{
       text-align: right;
       top: -30px;

--- a/vendor/assets/stylesheets/ombulabs/styleguide/4-molecules/_quotes.scss
+++ b/vendor/assets/stylesheets/ombulabs/styleguide/4-molecules/_quotes.scss
@@ -12,9 +12,6 @@
     font-size: 14px;
     font-weight: 700;
     margin-bottom: 20px;
-    @include respond-below(extra-small) {
-      margin-left: -2em;
-    }
   }
   .carousel{
     position: relative;
@@ -23,7 +20,7 @@
   }
   .nav-arrow{
     position: absolute;
-    top: 70px;
+    top: -20px;
     &.prev-arrow{
       right: 65px;
       a{
@@ -52,6 +49,14 @@
         color: $light_grey;
         transition: all 0.2s ease-in;
       }
+    }
+  }
+  @include respond-below(extra-small) {
+    h3 {
+      margin-bottom: 40px;
+    }
+    .nav-arrow {
+      top: 30px;
     }
   }
   .bx-wrapper{


### PR DESCRIPTION
This PR is for https://www.pivotaltracker.com/story/show/172178976

We changed the margin to left in the styleguide for extra-small so that it won't overlap with the text. I worked on this with @lubc 