### PR TITLE
OMBU-719 relax sass-rails dependency for rack upgrade

### DIFF
--- a/ombulabs-styleguide.gemspec
+++ b/ombulabs-styleguide.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*.rb'] + Dir['vendor/**/*']
 
   spec.add_dependency 'rails', '>= 5.0.0'
-  spec.add_dependency 'sass-rails', '~> 5.0'
+  spec.add_dependency 'sass-rails', '>= 5.0'
   # Font Awesome
   spec.add_dependency 'font-awesome-sass', '~> 5.12.0'
 end


### PR DESCRIPTION
This PR relax `sass-rails` dependency to allow `rack` upgrade in other projects